### PR TITLE
Change reporting URL only when empty

### DIFF
--- a/packit_service/worker/reporting.py
+++ b/packit_service/worker/reporting.py
@@ -91,7 +91,7 @@ class StatusReporter:
         self, state: CommitStatus, description: str, check_name: str, url: str = "",
     ):
         # required because pagure api doesnt accept, empty url
-        if isinstance(self.project, PagureProject):
+        if not url and isinstance(self.project, PagureProject):
             url = "https://wiki.centos.org/Manuals/ReleaseNotes/CentOSStream"
 
         logger.debug(f"Setting status for check '{check_name}': {description}")


### PR DESCRIPTION
Reporting code had a piece to set the URL when reporting to Pagure to
some not empty value. But this should be only done, when the URL to be
reported is and empty string. Otherwise it should be left as it is.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>